### PR TITLE
Fixes trivy scan exit code to fail pipeline on found issues

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -15,6 +15,7 @@ jobs:
           security-checks: 'vuln,config,secret'
           hide-progress: false
           format: 'table'
+          exit-code: '1'
         env:
           AQUA_KEY: ${{ secrets.AQUA_KEY }}
           AQUA_SECRET: ${{ secrets.AQUA_SECRET }}


### PR DESCRIPTION
This PR implements the exit code parameter on the trivy scan to exit 1 (error) if vulnerabilities are found, thereby failing the workflow.