### PR TITLE
Implements sarif output format and CodeQL Upload

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -14,10 +14,16 @@ jobs:
           scan-type: 'fs'
           security-checks: 'vuln,config,secret'
           hide-progress: false
-          format: 'table'
           exit-code: '1'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
         env:
           AQUA_KEY: ${{ secrets.AQUA_KEY }}
           AQUA_SECRET: ${{ secrets.AQUA_SECRET }}
           TRIVY_RUN_AS_PLUGIN: 'aqua'
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -15,6 +15,7 @@ jobs:
           security-checks: 'vuln,config,secret'
           hide-progress: false
           format: 'table'
+          exit-code: '1'
         env:
           AQUA_KEY: ${{ secrets.AQUA_KEY }}
           AQUA_SECRET: ${{ secrets.AQUA_SECRET }}


### PR DESCRIPTION
This PR sets the trivy scan output to SARIF format and adds a step to push the SARIF file to CodeQL, so scan results will be visible in the github scan results portal.